### PR TITLE
Fix error in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,7 +208,7 @@ How to find dashboards using specific data sources?
 ::
 
     # Display all dashboards which use a specific data source, filtered by data source name.
-    grafana-wtf explore dashboards --format=json | jq '.[] | select(.datasources | .[].type=="<datasource_name>")'
+    grafana-wtf explore dashboards --format=json | jq '.[] | select(.datasources | .[].name=="<datasource_name>")'
 
     # Display all dashboards using data sources with a specific type. Here: InfluxDB.
     grafana-wtf explore dashboards --format=json | jq '.[] | select(.datasources | .[].type=="influxdb")'


### PR DESCRIPTION
There was a typo in the README where the example to find a dashboards by data source name was trying to match against the "type" field, not the "name" field.